### PR TITLE
Fix trait/interface crash

### DIFF
--- a/bindgen/templates/ConcurrentHandleMap.cs
+++ b/bindgen/templates/ConcurrentHandleMap.cs
@@ -2,11 +2,11 @@ class ConcurrentHandleMap<T> where T: notnull {
     Dictionary<ulong, T> map = new Dictionary<ulong, T>();
 
     Object lock_ = new Object();
-    ulong currentHandle = 0;
+    ulong currentHandle = 1;
 
     public ulong Insert(T obj) {
         lock (lock_) {
-            currentHandle += 1;
+            currentHandle += 2;
             map[currentHandle] = obj;
             return currentHandle;
         }


### PR DESCRIPTION
ses <a href="https://github.com/mozilla/uniffi-rs/blob/main/docs/manual/src/internals/object_references.md#trait-interfaces">docs</a>
> Trait interfaces can also be implemented on the foreign side. In order to handle this efficiently, UniFFI must be able to distinguish foreign-generated handles from Rust ones. UniFFI handles this by setting the lowest bit on the handle to 1 for foreign handles. The Rust code generates lowered arc pointers, which have an alignment > 1 and therefore the lowest bit will never be set. Most foreign languages use a handle map to generate handles which makes it fairly simple to achive this: start the handle counter at 1 and always increment by 2. If a foreign language also uses raw pointers, they will also have an alignment > 1 and therefore they can OR the lowest bit to 1 without losing any information.