### PR TITLE
fix: update CI to build Docker image from repo instead of pulling bro…

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -24,20 +24,16 @@ jobs:
 
   test-bindings:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/nordsecurity/uniffi-bindgen-cs-test-runner:v0.2.1
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:
         submodules: 'true'
+    - name: Build test runner image
+      run: docker build -t uniffi-bindgen-cs-test-runner .
     - name: Test bindings
-      shell: bash
-      env:
-        # Github sets HOME to /github/home and breaks dependencies in Docker image..
-        # https://github.com/actions/runner/issues/863
-        HOME: /root
       run: |
-        source ~/.bashrc
-        ./build.sh
-        ./generate_bindings.sh
-        ./test_bindings.sh
+        docker run --rm \
+          --volume $PWD:/mounted_workdir \
+          --workdir /mounted_workdir \
+          -e HOME=/root \
+          uniffi-bindgen-cs-test-runner bash -c "source ~/.bashrc && ./build.sh && ./generate_bindings.sh && ./test_bindings.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0
 
-LABEL org.opencontainers.image.source=https://github.com/NordSecurity/uniffi-bindgen-cs
+LABEL org.opencontainers.image.source=https://github.com/sensslen/uniffi-bindgen-cs
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.88
 

--- a/docker.sh
+++ b/docker.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -euxo pipefail
 
+docker build -t uniffi-bindgen-cs-test-runner .
+
 docker run \
     -ti --rm \
     --volume $PWD:/mounted_workdir \
     --workdir /mounted_workdir \
-    ghcr.io/nordsecurity/uniffi-bindgen-cs-test-runner:v0.2.1 bash
+    uniffi-bindgen-cs-test-runner bash


### PR DESCRIPTION
…ken nordsecurity image

Agent-Logs-Url: https://github.com/sensslen/uniffi-bindgen-cs/sessions/75c7dce0-8303-469a-a34c-495de51a0142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored CI/CD testing workflow to build Docker images locally within the pipeline rather than pulling prebuilt container images
  * Updated Docker container metadata to reflect new repository location
  * Modified build execution script to use locally-built Docker image for test execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->